### PR TITLE
Rename GoBuster to WebBorer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 install:
-  - git clone http://h12.me/socks /home/travis/gopath/src/h12.me/socks
+  - git config --global http.followRedirects true
+  - git clone --depth 1 http://h12.me/socks /home/travis/gopath/src/h12.me/socks
   - go get -t -v ./...
 
 script:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-## GoBuster ##
+## WebBorer ##
 
-GoBuster is a directory-enumeration tool written in Go and targeting CLI usage.
+WebBorer is a directory-enumeration tool written in Go and targeting CLI usage.
+
+This project was formerly named 'GoBuster', but that had a namespace collision
+with OJ Reeves' excellent tool (which was released about the same time as I was
+preparing this for release).
 
 ### Features ###
 
@@ -15,15 +19,15 @@ GoBuster is a directory-enumeration tool written in Go and targeting CLI usage.
 
 Please see the CONTRIBUTING file in this directory.
 
-[![Build Status](https://travis-ci.org/Matir/gobuster.svg?branch=master)](https://travis-ci.org/Matir/gobuster)
-[![codecov](https://codecov.io/gh/Matir/gobuster/branch/master/graph/badge.svg)](https://codecov.io/gh/Matir/gobuster)
+[![Build Status](https://travis-ci.org/Matir/webborer.svg?branch=master)](https://travis-ci.org/Matir/webborer)
+[![codecov](https://codecov.io/gh/Matir/webborer/branch/master/graph/badge.svg)](https://codecov.io/gh/Matir/webborer)
 
 ### Copyright ###
-Copyright 2015-2016 Google Inc.
+Copyright 2015-2017 Google Inc.
 
-GoBuster is not an official Google product (experimental or otherwise), it is
+WebBorer is not an official Google product (experimental or otherwise), it is
 just code that happens to be owned by Google.
 
 ### Contact ###
-For questions about GoBuster, contact David Tomaschik
+For questions about WebBorer, contact David Tomaschik
 <<davidtomaschik@google.com>>

--- a/client/factory.go
+++ b/client/factory.go
@@ -16,7 +16,7 @@ package client
 
 import (
 	"fmt"
-	"github.com/Matir/gobuster/logging"
+	"github.com/Matir/webborer/logging"
 	"h12.me/socks"
 	"math/rand"
 	"net/http"

--- a/client/mock/mock.go
+++ b/client/mock/mock.go
@@ -20,7 +20,7 @@ package mock
 import (
 	"bytes"
 	"errors"
-	"github.com/Matir/gobuster/client"
+	"github.com/Matir/webborer/client"
 	"io/ioutil"
 	"net/http"
 	"net/url"

--- a/filter/expander.go
+++ b/filter/expander.go
@@ -15,8 +15,8 @@
 package filter
 
 import (
-	"github.com/Matir/gobuster/util"
-	"github.com/Matir/gobuster/workqueue"
+	"github.com/Matir/webborer/util"
+	"github.com/Matir/webborer/workqueue"
 	"net/url"
 	"strings"
 )

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -18,12 +18,12 @@
 package filter
 
 import (
-	"github.com/Matir/gobuster/client"
-	"github.com/Matir/gobuster/logging"
-	"github.com/Matir/gobuster/robots"
-	ss "github.com/Matir/gobuster/settings"
-	"github.com/Matir/gobuster/util"
-	"github.com/Matir/gobuster/workqueue"
+	"github.com/Matir/webborer/client"
+	"github.com/Matir/webborer/logging"
+	"github.com/Matir/webborer/robots"
+	ss "github.com/Matir/webborer/settings"
+	"github.com/Matir/webborer/util"
+	"github.com/Matir/webborer/workqueue"
 	"net/url"
 )
 

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -15,8 +15,8 @@
 package filter
 
 import (
-	"github.com/Matir/gobuster/client/mock"
-	"github.com/Matir/gobuster/settings"
+	"github.com/Matir/webborer/client/mock"
+	"github.com/Matir/webborer/settings"
 	"net/url"
 	"testing"
 )

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package logging provides a custom logging implementation for gobuster.
+// Package logging provides a custom logging implementation for webborer.
 package logging
 
 import (

--- a/main.go
+++ b/main.go
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Gobuster is a directory-enumeration tool writte in Go.
+// WebBorer is a directory-enumeration tool written in Go.
 package main
 
 import (
-	"github.com/Matir/gobuster/client"
-	"github.com/Matir/gobuster/filter"
-	"github.com/Matir/gobuster/logging"
-	"github.com/Matir/gobuster/results"
-	ss "github.com/Matir/gobuster/settings"
-	"github.com/Matir/gobuster/util"
-	"github.com/Matir/gobuster/wordlist"
-	"github.com/Matir/gobuster/worker"
-	"github.com/Matir/gobuster/workqueue"
+	"github.com/Matir/webborer/client"
+	"github.com/Matir/webborer/filter"
+	"github.com/Matir/webborer/logging"
+	"github.com/Matir/webborer/results"
+	ss "github.com/Matir/webborer/settings"
+	"github.com/Matir/webborer/util"
+	"github.com/Matir/webborer/wordlist"
+	"github.com/Matir/webborer/worker"
+	"github.com/Matir/webborer/workqueue"
 	"runtime"
 )
 
-// This is the main runner for gobuster.
+// This is the main runner for webborer.
 // TODO: separate the actual scanning from all of the setup steps
 func main() {
 	util.EnableStackTraces()

--- a/results/results.go
+++ b/results/results.go
@@ -18,7 +18,7 @@ package results
 import (
 	"encoding/csv"
 	"fmt"
-	ss "github.com/Matir/gobuster/settings"
+	ss "github.com/Matir/webborer/settings"
 	"io"
 	"net/http"
 	"net/url"

--- a/results/results_html.go
+++ b/results/results_html.go
@@ -15,7 +15,7 @@
 package results
 
 import (
-	"github.com/Matir/gobuster/logging"
+	"github.com/Matir/webborer/logging"
 	"html/template"
 	"io"
 	"os"
@@ -55,7 +55,7 @@ func (rm *HTMLResultsManager) Run(res <-chan Result) {
 }
 
 func (rm *HTMLResultsManager) writeHeader() {
-	header := `{{define "HEAD"}}<html><head><title>gobuster: {{.BaseURL}}</title></head><h2>Results for <a href="{{.BaseURL}}">{{.BaseURL}}</a></h2><table><tr><th>Code</th><th>URL</th><th>Size</th></tr>{{end}}`
+	header := `{{define "HEAD"}}<html><head><title>webborer: {{.BaseURL}}</title></head><h2>Results for <a href="{{.BaseURL}}">{{.BaseURL}}</a></h2><table><tr><th>Code</th><th>URL</th><th>Size</th></tr>{{end}}`
 	t, err := template.New("htmlResultsManager").Parse(header)
 	if err != nil {
 		logging.Logf(logging.LogWarning, "Error parsing a template: %s", err.Error())

--- a/results/results_test.go
+++ b/results/results_test.go
@@ -15,7 +15,7 @@
 package results
 
 import (
-	"github.com/Matir/gobuster/settings"
+	"github.com/Matir/webborer/settings"
 	"net/url"
 	"testing"
 )

--- a/robots/robots.go
+++ b/robots/robots.go
@@ -17,7 +17,7 @@ package robots
 
 import (
 	"bytes"
-	"github.com/Matir/gobuster/client"
+	"github.com/Matir/webborer/client"
 	"io/ioutil"
 	"net/url"
 )

--- a/robots/robots_test.go
+++ b/robots/robots_test.go
@@ -15,7 +15,7 @@
 package robots
 
 import (
-	"github.com/Matir/gobuster/client/mock"
+	"github.com/Matir/webborer/client/mock"
 	"io/ioutil"
 	"net/http"
 	"net/url"

--- a/settings/config_unix.go
+++ b/settings/config_unix.go
@@ -23,13 +23,13 @@ import (
 )
 
 var defaultConfigPaths = []string{
-	// This will be prepended by $HOME/.config/gobuster.conf
-	"/etc/gobuster.conf",
+	// This will be prepended by $HOME/.config/webborer.conf
+	"/etc/webborer.conf",
 }
 
 func init() {
 	if usr, err := user.Current(); err == nil {
-		path := filepath.Join(usr.HomeDir, ".config", "gobuster.conf")
+		path := filepath.Join(usr.HomeDir, ".config", "webborer.conf")
 		defaultConfigPaths = append([]string{path}, defaultConfigPaths...)
 	}
 }

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package settings provides a central interface to gobuster settings.
+// Package settings provides a central interface to webborer settings.
 package settings
 
 import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/Matir/gobuster/logging"
+	"github.com/Matir/webborer/logging"
 	"net/url"
 	"os"
 	"runtime"
@@ -96,7 +96,7 @@ var robotsModeStrings = [...]string{
 	"seed",
 }
 
-var DefaultUserAgent = "GoBuster 0.01"
+var DefaultUserAgent = "WebBorer 0.01"
 var outputFormats []string
 
 // StringSliceFlag is a flag.Value that takes a comma-separated string and turns

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -15,7 +15,7 @@
 package settings
 
 import (
-	"github.com/Matir/gobuster/logging"
+	"github.com/Matir/webborer/logging"
 	"testing"
 	"time"
 )

--- a/util/utils.go
+++ b/util/utils.go
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package util provides a set of utility and helper functions for gobuster.
+// Package util provides a set of utility and helper functions for webborer.
 package util
 
 import (
-	"github.com/Matir/gobuster/logging"
+	"github.com/Matir/webborer/logging"
 	"net/url"
 	"os"
 	"os/signal"
@@ -138,8 +138,8 @@ func getParentPathsString(childPath string) []string {
 
 // Debug profiling support
 func EnableCPUProfiling() func() {
-	if profFile, err := os.Create("gobuster.prof"); err != nil {
-		logging.Logf(logging.LogError, "Unable to open gobuster.prof for profiling: %v", err)
+	if profFile, err := os.Create("webborer.prof"); err != nil {
+		logging.Logf(logging.LogError, "Unable to open webborer.prof for profiling: %v", err)
 	} else {
 		pprof.StartCPUProfile(profFile)
 		sigintChan := make(chan os.Signal, 1)

--- a/worker/htmlworker.go
+++ b/worker/htmlworker.go
@@ -15,9 +15,9 @@
 package worker
 
 import (
-	"github.com/Matir/gobuster/logging"
-	"github.com/Matir/gobuster/util"
-	"github.com/Matir/gobuster/workqueue"
+	"github.com/Matir/webborer/logging"
+	"github.com/Matir/webborer/util"
+	"github.com/Matir/webborer/workqueue"
 	"golang.org/x/net/html"
 	"io"
 	"net/http"

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -18,12 +18,12 @@ package worker
 
 import (
 	"fmt"
-	"github.com/Matir/gobuster/client"
-	"github.com/Matir/gobuster/logging"
-	"github.com/Matir/gobuster/results"
-	ss "github.com/Matir/gobuster/settings"
-	"github.com/Matir/gobuster/util"
-	"github.com/Matir/gobuster/workqueue"
+	"github.com/Matir/webborer/client"
+	"github.com/Matir/webborer/logging"
+	"github.com/Matir/webborer/results"
+	ss "github.com/Matir/webborer/settings"
+	"github.com/Matir/webborer/util"
+	"github.com/Matir/webborer/workqueue"
 	"io"
 	"net/http"
 	"net/url"

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -15,9 +15,9 @@
 package worker
 
 import (
-	"github.com/Matir/gobuster/client/mock"
-	"github.com/Matir/gobuster/results"
-	"github.com/Matir/gobuster/settings"
+	"github.com/Matir/webborer/client/mock"
+	"github.com/Matir/webborer/results"
+	"github.com/Matir/webborer/settings"
 	"net/http"
 	"net/url"
 	"strings"

--- a/workqueue/workcounter.go
+++ b/workqueue/workcounter.go
@@ -15,7 +15,7 @@
 package workqueue
 
 import (
-	"github.com/Matir/gobuster/logging"
+	"github.com/Matir/webborer/logging"
 	"sync"
 )
 

--- a/workqueue/workqueue.go
+++ b/workqueue/workqueue.go
@@ -17,10 +17,10 @@
 package workqueue
 
 import (
-	"github.com/Matir/gobuster/client"
-	"github.com/Matir/gobuster/logging"
-	"github.com/Matir/gobuster/robots"
-	"github.com/Matir/gobuster/util"
+	"github.com/Matir/webborer/client"
+	"github.com/Matir/webborer/logging"
+	"github.com/Matir/webborer/robots"
+	"github.com/Matir/webborer/util"
 	"net/url"
 	"sync"
 )


### PR DESCRIPTION
To avoid naming conflict with https://github.com/OJ/gobuster, I'm renaming GoBuster to WebBorer.