### PR TITLE
Include the Content-Type in result structs.

### DIFF
--- a/results/results.go
+++ b/results/results.go
@@ -37,6 +37,8 @@ type Result struct {
 	Redir *url.URL
 	// Content length
 	Length int64
+	// Content-type header
+	ContentType string
 }
 
 // ResultsManager provides an interface for reading results from a channel and

--- a/results/results_html.go
+++ b/results/results_html.go
@@ -55,7 +55,7 @@ func (rm *HTMLResultsManager) Run(res <-chan Result) {
 }
 
 func (rm *HTMLResultsManager) writeHeader() {
-	header := `{{define "HEAD"}}<html><head><title>webborer: {{.BaseURL}}</title></head><h2>Results for <a href="{{.BaseURL}}">{{.BaseURL}}</a></h2><table><tr><th>Code</th><th>URL</th><th>Size</th></tr>{{end}}`
+	header := `{{define "HEAD"}}<html><head><title>webborer: {{.BaseURL}}</title></head><h2>Results for <a href="{{.BaseURL}}">{{.BaseURL}}</a></h2><table><tr><th>Code</th><th>URL</th><th>Size</th><th>Content-Type</th></tr>{{end}}`
 	t, err := template.New("htmlResultsManager").Parse(header)
 	if err != nil {
 		logging.Logf(logging.LogWarning, "Error parsing a template: %s", err.Error())
@@ -85,7 +85,7 @@ func (rm *HTMLResultsManager) writeFooter() {
 
 func (rm *HTMLResultsManager) writeResult(res *Result) {
 	// TODO: don't rebuild the template with each row
-	tmpl := `{{define "ROW"}}<tr><td>{{.Code}}</td><td><a href="{{.URL.String}}">{{.URL.String}}</a></td><td>{{if ge .Length 0}}{{.Length}}{{end}}</td></tr>{{end}}`
+	tmpl := `{{define "ROW"}}<tr><td>{{.Code}}</td><td><a href="{{.URL.String}}">{{.URL.String}}</a></td><td>{{if ge .Length 0}}{{.Length}}{{end}}</td><td>{{.ContentType}}</td></tr>{{end}}`
 	t, err := template.New("htmlResultsManager").Parse(tmpl)
 	if err != nil {
 		logging.Logf(logging.LogWarning, "Error parsing a template: %s", err.Error())

--- a/results/results_html_test.go
+++ b/results/results_html_test.go
@@ -28,8 +28,9 @@ func TestHTMLResultsManager_Basic(t *testing.T) {
 	}
 	rchan := make(chan Result)
 	res := Result{
-		URL:  &url.URL{Scheme: "http", Host: "localhost", Path: "/"},
-		Code: 200,
+		URL:         &url.URL{Scheme: "http", Host: "localhost", Path: "/"},
+		Code:        200,
+		ContentType: "text/html",
 	}
 	mgr.Run(rchan)
 	rchan <- res

--- a/results/results_test.go
+++ b/results/results_test.go
@@ -23,8 +23,9 @@ import (
 func makeTestResults() []Result {
 	return []Result{
 		Result{
-			URL:  &url.URL{Scheme: "http", Host: "localhost", Path: "/"},
-			Code: 200,
+			URL:         &url.URL{Scheme: "http", Host: "localhost", Path: "/"},
+			Code:        200,
+			ContentType: "text/html",
 		},
 		Result{
 			URL:  &url.URL{Scheme: "http", Host: "localhost", Path: "/x"},

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -185,10 +185,11 @@ func (w *Worker) TryURL(task *url.URL) bool {
 			redir = w.redir.URL
 		}
 		w.rchan <- results.Result{
-			URL:    task,
-			Code:   resp.StatusCode,
-			Redir:  redir,
-			Length: resp.ContentLength,
+			URL:         task,
+			Code:        resp.StatusCode,
+			Redir:       redir,
+			Length:      resp.ContentLength,
+			ContentType: resp.Header.Get("Content-Type"),
 		}
 		tryMangle = w.KeepSpidering(resp.StatusCode)
 	}
@@ -233,7 +234,7 @@ func Mangle(basename string) []string {
 		".%s.swp", // VIM Swap File
 		"%s~",     // Backup file
 		"%s.bak",  // Backup file
-		"%s.orig", //Backup file
+		"%s.orig", // Backup file
 	}
 	res := make([]string, len(mangleRules))
 	for i, rule := range mangleRules {


### PR DESCRIPTION
Only rendered in HTML view currently.

Closes #11.