### PR TITLE
Add support for other HTTP Methods

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -28,7 +28,7 @@ import (
 // support our use case.
 type Client interface {
 	RequestURL(*url.URL) (*http.Response, error)
-	Request(*url.URL, string, http.Header) (*http.Response, error)
+	Request(*url.URL, string, string, http.Header) (*http.Response, error)
 	SetCheckRedirect(func(*http.Request, []*http.Request) error)
 }
 
@@ -53,15 +53,13 @@ type httpClient struct {
 // Handles HTTP Authentication & Custom Headers
 func (c *httpClient) RequestURL(u *url.URL) (*http.Response, error) {
 	logging.Infof("Deprectated function RequestURL is called.")
-	return c.Request(u, "", nil)
+	return c.Request(u, "", "GET", nil)
 }
 
 // Request the URL given with optional overrides.
 //
 // Handles HTTP Authentication & Custom Headers
-func (c *httpClient) Request(u *url.URL, host string, header http.Header) (*http.Response, error) {
-	// TODO: support other methods
-	method := "GET"
+func (c *httpClient) Request(u *url.URL, host, method string, header http.Header) (*http.Response, error) {
 	req := c.makeRequest(u, method, host, header)
 	resp, err := c.Client.Do(req)
 	if err != nil {

--- a/client/mock/mock.go
+++ b/client/mock/mock.go
@@ -30,6 +30,7 @@ type MockClientFactory struct {
 	ForeverClient *MockClient
 	NextClient    *MockClient
 }
+
 type MockClient struct {
 	ForeverResponse *http.Response
 	NextResponse    *http.Response
@@ -51,10 +52,10 @@ func (f *MockClientFactory) Get() client.Client {
 }
 
 func (c *MockClient) RequestURL(u *url.URL) (*http.Response, error) {
-	return c.Request(u, "", nil)
+	return c.Request(u, "", "GET", nil)
 }
 
-func (c *MockClient) Request(u *url.URL, host string, header http.Header) (*http.Response, error) {
+func (c *MockClient) Request(u *url.URL, host, method string, header http.Header) (*http.Response, error) {
 	c.Requests = append(c.Requests, u)
 	if c.Redir != nil && c.CheckRedirect != nil {
 		req := &http.Request{URL: c.Redir}

--- a/filter/extension_expander.go
+++ b/filter/extension_expander.go
@@ -1,0 +1,71 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"fmt"
+	"github.com/Matir/webborer/task"
+	"github.com/Matir/webborer/workqueue"
+	"net/url"
+	"strings"
+)
+
+// Expand extensions when none are given
+type ExtensionExpander struct {
+	extensions []string
+	adder      workqueue.QueueAddCount
+}
+
+func NewExtensionExpander(extensions []string) *ExtensionExpander {
+	return &ExtensionExpander{extensions: extensions}
+}
+
+func (e *ExtensionExpander) SetAddCount(adder workqueue.QueueAddCount) {
+	e.adder = adder
+}
+
+func (e *ExtensionExpander) Expand(in <-chan *task.Task) <-chan *task.Task {
+	outChan := make(chan *task.Task)
+	go func() {
+		defer close(outChan)
+		for it := range in {
+			// Un modified form
+			outChan <- it
+			if hasExtension(it.URL) {
+				continue
+			}
+			if isDirectory(it.URL) {
+				continue
+			}
+			for _, ext := range e.extensions {
+				t := it.Copy()
+				t.URL.Path = fmt.Sprintf("%s.%s", it.URL.Path, ext)
+				outChan <- t
+			}
+		}
+	}()
+	return outChan
+}
+
+func hasExtension(URL *url.URL) bool {
+	if slashPos := strings.LastIndex(URL.Path, "/"); slashPos > -1 {
+		return strings.LastIndex(URL.Path, ".") > slashPos
+	}
+	return false
+}
+
+func isDirectory(URL *url.URL) bool {
+	return strings.HasSuffix(URL.Path, "/")
+}

--- a/filter/extension_expander.go
+++ b/filter/extension_expander.go
@@ -40,6 +40,7 @@ func (e *ExtensionExpander) Expand(in <-chan *task.Task) <-chan *task.Task {
 	outChan := make(chan *task.Task)
 	go func() {
 		defer close(outChan)
+		numExtensions := len(e.extensions)
 		for it := range in {
 			// Un modified form
 			outChan <- it
@@ -49,6 +50,7 @@ func (e *ExtensionExpander) Expand(in <-chan *task.Task) <-chan *task.Task {
 			if isDirectory(it.URL) {
 				continue
 			}
+			e.adder(numExtensions)
 			for _, ext := range e.extensions {
 				t := it.Copy()
 				t.URL.Path = fmt.Sprintf("%s.%s", it.URL.Path, ext)

--- a/main.go
+++ b/main.go
@@ -108,6 +108,8 @@ func main() {
 
 	headerExpander := filter.NewHeaderExpander(settings.OptionalHeader.Header())
 	headerExpander.SetAddCount(queue.GetAddCount())
+	extensionExpander := filter.NewExtensionExpander(settings.Extensions)
+	extensionExpander.SetAddCount(queue.GetAddCount())
 
 	filter := filter.NewWorkFilter(settings, queue.GetDoneFunc())
 
@@ -121,6 +123,7 @@ func main() {
 	workChan := queue.GetWorkChan()
 	workChan = expander.Expand(workChan)
 	workChan = headerExpander.Expand(workChan)
+	workChan = extensionExpander.Expand(workChan)
 	workChan = filter.RunFilter(workChan)
 
 	logging.Logf(logging.LogDebug, "Creating results manager...")

--- a/results/results.go
+++ b/results/results.go
@@ -19,6 +19,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	ss "github.com/Matir/webborer/settings"
+	"github.com/Matir/webborer/task"
 	"io"
 	"net/http"
 	"net/url"
@@ -42,7 +43,9 @@ type Result struct {
 	// Content-type header
 	ContentType string
 	// Known Headers
-	Header http.Header
+	RequestHeader http.Header
+	// Response headers
+	ResponseHeader http.Header
 	// Group used for potentially bucketing results
 	ResultGroup string
 }
@@ -53,6 +56,12 @@ func NewResult(URL *url.URL, host string) *Result {
 		Host: host,
 	}
 	rv.ResultGroup = GetResultGroup(rv)
+	return rv
+}
+
+func NewResultForTask(t *task.Task) *Result {
+	rv := NewResult(t.URL, t.Host)
+	rv.RequestHeader = t.Header
 	return rv
 }
 

--- a/results/results_diff.go
+++ b/results/results_diff.go
@@ -61,16 +61,16 @@ func NewBaselineResult(results ...Result) (*BaselineResult, error) {
 		}
 	}
 
-	for k, _ := range res.Header {
+	for k, _ := range res.ResponseHeader {
 		k = strings.ToLower(k)
 		if util.StringSliceContains(neverImportant, k) {
 			continue
 		}
 		matches := true
-		baseline := results[0].Header[k][0]
+		baseline := results[0].ResponseHeader[k][0]
 		if len(results) > 0 {
 			for _, r := range results[1:] {
-				if r.Header[k][0] != baseline {
+				if r.ResponseHeader[k][0] != baseline {
 					matches = false
 					break
 				}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -67,6 +67,8 @@ type ScanSettings struct {
 	OutputPath string
 	// User-Agent for requests
 	UserAgent string
+	// HTTP Method to use
+	Method string
 	// Whether to include redirects in reporting
 	IncludeRedirects bool
 	// How to handle Robots.txt
@@ -101,6 +103,7 @@ func NewScanSettings() *ScanSettings {
 	settings := &ScanSettings{
 		Threads:        runtime.NumCPU(),
 		Extensions:     []string{"html", "php", "asp", "aspx"},
+		Method:         "GET",
 		Mangle:         true,
 		QueueSize:      1024,
 		Timeout:        30 * time.Second,
@@ -168,6 +171,7 @@ func (settings *ScanSettings) InitFlags() {
 	flag.StringVar(&settings.HTTPUsername, "http-username", "", "Username to be used for HTTP Auth")
 	flag.StringVar(&settings.HTTPPassword, "http-password", "", "Password to be used for HTTP Auth")
 	flag.BoolVar(&settings.ProgressBar, "progress", true, "Display a progress bar on stderr.")
+	flag.StringVar(&settings.Method, "method", "GET", "HTTP Method to use.")
 
 	// Debugging flags
 	flag.BoolVar(&settings.DebugCPUProf, "debug-cpuprof", false, "[DEBUG] CPU Profiling")

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -136,16 +136,6 @@ func (w *Worker) HandleTask(t *task.Task) {
 		if w.KeepSpidering(code) {
 			w.TryMangleTask(t)
 		}
-		// TODO: move this to an expander!
-		if !util.URLHasExtension(t.URL) {
-			for _, ext := range w.settings.Extensions {
-				t := t.Copy()
-				t.URL.Path += "." + ext
-				if w.KeepSpidering(w.TryTask(t)) {
-					w.TryMangleTask(t)
-				}
-			}
-		}
 	}
 	// Mark as done
 	w.done(1)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -163,7 +163,8 @@ func (w *Worker) TryTask(t *task.Task) int {
 	logging.Logf(logging.LogInfo, "Trying: %s", t.String())
 	w.redir = nil
 	defer w.Sleep()
-	if resp, err := w.client.Request(t.URL, t.Host, t.Header); err != nil && w.redir == nil {
+	method := w.settings.Method
+	if resp, err := w.client.Request(t.URL, t.Host, method, t.Header); err != nil && w.redir == nil {
 		result := w.ResultForError(t, resp, err)
 		w.rchan <- result
 		if resp == nil {


### PR DESCRIPTION
This adds basic support for other HTTP verbs, though only one can be used at a time still (no mixing).  Fixes #48.